### PR TITLE
Remove Spam From Muzzled Users

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     }
   },
   "lint-staged": {
-    "*.{ts,css,json,md}": [
+    "*.{ts, spec.ts, css,json,md}": [
       "npm run lint",
       "git add"
     ]

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     }
   },
   "lint-staged": {
-    "*.{js,css,json,md}": [
+    "*.{ts,css,json,md}": [
       "npm run lint",
       "git add"
     ]

--- a/src/routes/define-route.ts
+++ b/src/routes/define-route.ts
@@ -9,7 +9,7 @@ import {
   define,
   formatDefs
 } from "../utils/define/define-utils";
-import { isMuzzled } from "../utils/muzzle/muzzle-utils";
+import { muzzled } from "../utils/muzzle/muzzle-utils";
 import { sendResponse } from "../utils/slack/slack-utils";
 
 export const defineRoutes: Router = express.Router();
@@ -24,10 +24,10 @@ defineRoutes.post("/define", async (req: Request, res: Response) => {
       attachments: formatDefs(defined.list)
     };
 
-    if (!isMuzzled(request.user_id)) {
+    if (muzzled.has(request.user_id)) {
       sendResponse(request.response_url, response);
       res.status(200).send();
-    } else if (isMuzzled(request.user_id)) {
+    } else if (muzzled.has(request.user_id)) {
       res.send(`Sorry, can't do that while muzzled.`);
     }
   } catch (e) {

--- a/src/routes/mock-route.ts
+++ b/src/routes/mock-route.ts
@@ -4,7 +4,7 @@ import {
   ISlashCommandRequest
 } from "../shared/models/slack/slack-models";
 import { mock } from "../utils/mock/mock-utils";
-import { isMuzzled } from "../utils/muzzle/muzzle-utils";
+import { muzzled } from "../utils/muzzle/muzzle-utils";
 import { sendResponse } from "../utils/slack/slack-utils";
 
 export const mockRoutes: Router = express.Router();
@@ -21,10 +21,10 @@ mockRoutes.post("/mock", (req, res) => {
     response_type: "in_channel",
     text: `<@${request.user_id}>`
   };
-  if (!isMuzzled(request.user_id)) {
+  if (!muzzled.has(request.user_id)) {
     sendResponse(request.response_url, response);
     res.status(200).send();
-  } else if (isMuzzled(request.user_id)) {
+  } else if (muzzled.has(request.user_id)) {
     res.send(`Sorry, can't do that while muzzled.`);
   }
 });

--- a/src/routes/muzzle-route.ts
+++ b/src/routes/muzzle-route.ts
@@ -18,6 +18,7 @@ import { getUserId, getUserName } from "../utils/slack/slack-utils";
 export const muzzleRoutes: Router = express.Router();
 const muzzleToken: any = process.env.muzzleBotToken;
 const web: WebClient = new WebClient(muzzleToken);
+const MAX_SUPPRESSIONS: number = 10;
 
 muzzleRoutes.post("/muzzle/handle", (req: Request, res: Response) => {
   const request: IEventRequest = req.body;
@@ -33,7 +34,12 @@ muzzleRoutes.post("/muzzle/handle", (req: Request, res: Response) => {
 
     web.chat.delete(deleteRequest).catch(e => console.error(e));
 
-    if (muzzled.get(request.event.user)!.suppressionCount < 10) {
+    if (muzzled.get(request.event.user)!.suppressionCount <= MAX_SUPPRESSIONS) {
+      muzzled.set(request.event.user, {
+        suppressionCount: ++muzzled.get(request.event.user)!.suppressionCount,
+        muzzledBy: muzzled.get(request.event.user)!.muzzledBy
+      });
+
       const postRequest: ChatPostMessageArguments = {
         token: muzzleToken,
         channel: request.event.channel,

--- a/src/routes/muzzle-route.ts
+++ b/src/routes/muzzle-route.ts
@@ -8,8 +8,8 @@ import {
 } from "../shared/models/slack/slack-models";
 import {
   addUserToMuzzled,
-  isMuzzled,
-  muzzle
+  muzzle,
+  muzzled
 } from "../utils/muzzle/muzzle-utils";
 import { getUserId, getUserName } from "../utils/slack/slack-utils";
 
@@ -20,7 +20,7 @@ const web: WebClient = new WebClient(muzzleToken);
 muzzleRoutes.post("/muzzle/handle", (req: Request, res: Response) => {
   const request: IEventRequest = req.body;
   console.log(request);
-  if (isMuzzled(request.event.user)) {
+  if (muzzled.has(request.event.user)) {
     console.log(`${request.event.user} is muzzled! Suppressing his voice...`);
     const deleteRequest: IDeleteMessageRequest = {
       token: muzzleToken,

--- a/src/routes/muzzle-route.ts
+++ b/src/routes/muzzle-route.ts
@@ -46,7 +46,6 @@ muzzleRoutes.post("/muzzle", (req: Request, res: Response) => {
   const request: ISlashCommandRequest = req.body;
   const userId: string = getUserId(request.text);
   const userName: string = getUserName(request.text);
-  console.log(request);
   try {
     res.send(addUserToMuzzled(userId, userName, request.user_id));
   } catch (e) {

--- a/src/routes/muzzle-route.ts
+++ b/src/routes/muzzle-route.ts
@@ -18,7 +18,7 @@ import { getUserId, getUserName } from "../utils/slack/slack-utils";
 export const muzzleRoutes: Router = express.Router();
 const muzzleToken: any = process.env.muzzleBotToken;
 const web: WebClient = new WebClient(muzzleToken);
-const MAX_SUPPRESSIONS: number = 10;
+const MAX_SUPPRESSIONS: number = 7;
 
 muzzleRoutes.post("/muzzle/handle", (req: Request, res: Response) => {
   const request: IEventRequest = req.body;
@@ -34,7 +34,7 @@ muzzleRoutes.post("/muzzle/handle", (req: Request, res: Response) => {
 
     web.chat.delete(deleteRequest).catch(e => console.error(e));
 
-    if (muzzled.get(request.event.user)!.suppressionCount <= MAX_SUPPRESSIONS) {
+    if (muzzled.get(request.event.user)!.suppressionCount < MAX_SUPPRESSIONS) {
       muzzled.set(request.event.user, {
         suppressionCount: ++muzzled.get(request.event.user)!.suppressionCount,
         muzzledBy: muzzled.get(request.event.user)!.muzzledBy

--- a/src/shared/models/muzzle/muzzle-models.ts
+++ b/src/shared/models/muzzle/muzzle-models.ts
@@ -1,0 +1,8 @@
+export interface IMuzzled {
+  suppressionCount: number;
+  muzzledBy: string;
+}
+
+export interface IMuzzler {
+  muzzleCount: number;
+}

--- a/src/shared/models/slack/slack-models.ts
+++ b/src/shared/models/slack/slack-models.ts
@@ -4,19 +4,6 @@ export interface IChannelResponse {
   attachments: IAttachment[];
 }
 
-export interface IDeleteMessageRequest {
-  token: string;
-  channel: string;
-  ts: string;
-  as_user: boolean;
-}
-
-export interface IPostMessageRequest {
-  token: string;
-  channel: string;
-  text: string;
-}
-
 export interface ISlashCommandRequest {
   text: string;
   user_id: string;

--- a/src/utils/muzzle/muzzle-utils.spec.ts
+++ b/src/utils/muzzle/muzzle-utils.spec.ts
@@ -42,7 +42,7 @@ describe("muzzle-utils", () => {
             testData.friendlyName,
             testData.requestor
           )
-        ).to.throw();
+        ).to.throw(`${testData.friendlyName} is already muzzled!`);
       });
 
       it("should throw an error if a requestor tries to muzzle someone while the requestor is muzzled", () => {
@@ -53,7 +53,7 @@ describe("muzzle-utils", () => {
             testData.friendlyName,
             testData.user
           )
-        ).to.throw();
+        ).to.throw(`You can't muzzle someone if you are already muzzled!`);
       });
     });
 

--- a/src/utils/muzzle/muzzle-utils.spec.ts
+++ b/src/utils/muzzle/muzzle-utils.spec.ts
@@ -1,48 +1,92 @@
 import { expect } from "chai";
 import {
   addUserToMuzzled,
-  isMuzzled,
   muzzled,
+  muzzlers,
   removeMuzzle
 } from "./muzzle-utils";
 
 describe("muzzle-utils", () => {
   const testData = {
     user: "test-user",
+    user2: "test-user2",
     friendlyName: "test-muzzler",
     requestor: "test-requestor"
   };
 
   beforeEach(() => {
-    muzzled.length = 0;
+    muzzled.clear();
+    muzzlers.clear();
     addUserToMuzzled(testData.user, testData.friendlyName, testData.requestor);
   });
 
   describe("addUserToMuzzled()", () => {
-    it("should add a user to the muzzled array", () => {
-      expect(muzzled.length).to.equal(1);
-      expect(isMuzzled(testData.user)).to.equal(true);
+    describe("muzzled", () => {
+      it("should add a user to the muzzled map", () => {
+        expect(muzzled.size).to.equal(1);
+        expect(muzzled.has(testData.user)).to.equal(true);
+      });
+
+      it("should return an added user with IMuzzled attributes", () => {
+        expect(muzzled.get(testData.user)!.suppressionCount).to.equal(0);
+        expect(muzzled.get(testData.user)!.muzzledBy).to.equal(
+          testData.requestor
+        );
+      });
+
+      it("should throw an error if a user tries to muzzle an already muzzled user", () => {
+        expect(muzzled.has(testData.user)).to.equal(true);
+        expect(() =>
+          addUserToMuzzled(
+            testData.user,
+            testData.friendlyName,
+            testData.requestor
+          )
+        ).to.throw();
+      });
+
+      it("should throw an error if a requestor tries to muzzle someone while the requestor is muzzled", () => {
+        expect(muzzled.has(testData.user)).to.equal(true);
+        expect(() =>
+          addUserToMuzzled(
+            testData.requestor,
+            testData.friendlyName,
+            testData.user
+          )
+        ).to.throw();
+      });
+    });
+
+    describe("muzzlers", () => {
+      it("should add a user to the muzzlers map", () => {
+        expect(muzzlers.size).to.equal(1);
+        expect(muzzlers.has(testData.requestor)).to.equal(true);
+      });
+
+      it("should return an added user with IMuzzler attributes", () => {
+        expect(muzzlers.get(testData.requestor)!.muzzleCount).to.equal(1);
+      });
+
+      it("should increment a requestors muzzle count on a second addUserToMuzzled() call", () => {
+        addUserToMuzzled(
+          testData.user2,
+          testData.friendlyName,
+          testData.requestor
+        );
+        expect(muzzled.size).to.equal(2);
+        expect(muzzlers.has(testData.requestor)).to.equal(true);
+        expect(muzzlers.get(testData.requestor)!.muzzleCount).to.equal(2);
+      });
     });
   });
 
   describe("removeMuzzle()", () => {
     it("should remove a user from the muzzled array", () => {
-      expect(muzzled.length).to.equal(1);
-      expect(isMuzzled(testData.user)).to.equal(true);
+      expect(muzzled.size).to.equal(1);
+      expect(muzzled.has(testData.user)).to.equal(true);
       removeMuzzle(testData.user);
-      expect(isMuzzled(testData.user)).to.equal(false);
-      expect(muzzled.length).to.equal(0);
-    });
-  });
-
-  describe("isMuzzled()", () => {
-    it("should return true if a user is muzzled", () => {
-      expect(isMuzzled(testData.user)).to.equal(true);
-    });
-
-    it("should return false if a user is not muzzled", () => {
-      removeMuzzle(testData.user);
-      expect(isMuzzled(testData.user)).to.equal(false);
+      expect(muzzled.has(testData.user)).to.equal(false);
+      expect(muzzled.size).to.equal(0);
     });
   });
 });


### PR DESCRIPTION
- Sets a limit of 7 suppressed messages per user who is currently muzzled
- Converts`muzzled` from array -> Map
- Adjust pre-commit script to work properly
- Adds more unit tests for muzzle