### PR TITLE
Max Muzzles Per Hour

### DIFF
--- a/src/shared/models/muzzle/muzzle-models.ts
+++ b/src/shared/models/muzzle/muzzle-models.ts
@@ -5,5 +5,5 @@ export interface IMuzzled {
 
 export interface IMuzzler {
   muzzleCount: number;
-  muzzleCountRemover?: Timeout;
+  muzzleCountRemover?: number;
 }

--- a/src/shared/models/muzzle/muzzle-models.ts
+++ b/src/shared/models/muzzle/muzzle-models.ts
@@ -5,4 +5,5 @@ export interface IMuzzled {
 
 export interface IMuzzler {
   muzzleCount: number;
+  muzzleCountRemover?: Timeout;
 }

--- a/src/shared/models/muzzle/muzzle-models.ts
+++ b/src/shared/models/muzzle/muzzle-models.ts
@@ -5,5 +5,5 @@ export interface IMuzzled {
 
 export interface IMuzzler {
   muzzleCount: number;
-  muzzleCountRemover?: number;
+  muzzleCountRemover?: NodeJS.Timeout;
 }

--- a/src/utils/muzzle/muzzle-utils.spec.ts
+++ b/src/utils/muzzle/muzzle-utils.spec.ts
@@ -4,7 +4,8 @@ import {
   MAX_MUZZLES,
   muzzled,
   muzzlers,
-  removeMuzzle
+  removeMuzzle,
+  removeMuzzler
 } from "./muzzle-utils";
 
 describe("muzzle-utils", () => {
@@ -151,6 +152,23 @@ describe("muzzle-utils", () => {
       removeMuzzle(testData.user);
       expect(muzzled.has(testData.user)).to.equal(false);
       expect(muzzled.size).to.equal(0);
+    });
+  });
+
+  describe("removeMuzzler()", () => {
+    it("should remove a user from the muzzler array", () => {
+      addUserToMuzzled(
+        testData.user,
+        testData.friendlyName,
+        testData.requestor
+      );
+      expect(muzzled.size).to.equal(1);
+      expect(muzzled.has(testData.user)).to.equal(true);
+      expect(muzzlers.size).to.equal(1);
+      expect(muzzlers.has(testData.requestor)).to.equal(true);
+      removeMuzzler(testData.requestor);
+      expect(muzzlers.has(testData.requestor)).to.equal(false);
+      expect(muzzlers.size).to.equal(0);
     });
   });
 });

--- a/src/utils/muzzle/muzzle-utils.ts
+++ b/src/utils/muzzle/muzzle-utils.ts
@@ -64,7 +64,7 @@ export function addUserToMuzzled(
     // Add requestor to muzzlers
     muzzlers.set(requestor, {
       muzzleCount,
-      muzzleCountRemover: setTimeout(
+      muzzleCountRemover: window.setTimeout(
         () => decrementMuzzleCount(requestor),
         MAX_TIME_BETWEEN_MUZZLES
       )
@@ -74,10 +74,10 @@ export function addUserToMuzzled(
       muzzlers.has(requestor) &&
       muzzlers.get(requestor)!.muzzleCountRemover
     ) {
-      clearTimeout(muzzlers.get(requestor)!.muzzleCountRemover);
+      window.clearTimeout(muzzlers.get(requestor)!.muzzleCountRemover);
       muzzlers.set(requestor, {
         muzzleCount: muzzlers.get(requestor)!.muzzleCount,
-        muzzleCountRemover: setTimeout(
+        muzzleCountRemover: window.setTimeout(
           () =>
             muzzlers.get(requestor)!.muzzleCount === MAX_MUZZLES
               ? removeMuzzler(requestor)
@@ -89,7 +89,7 @@ export function addUserToMuzzled(
     console.log(
       `${friendlyMuzzle} is now muzzled for ${timeToMuzzle} milliseconds`
     );
-    setTimeout(() => removeMuzzle(toMuzzle), timeToMuzzle);
+    window.setTimeout(() => removeMuzzle(toMuzzle), timeToMuzzle);
     return `Succesfully muzzled ${friendlyMuzzle} for ${
       +seconds === 60
         ? minutes + 1 + "m00s"

--- a/src/utils/muzzle/muzzle-utils.ts
+++ b/src/utils/muzzle/muzzle-utils.ts
@@ -1,5 +1,4 @@
 import { IMuzzled, IMuzzler } from "../../shared/models/muzzle/muzzle-models";
-
 // Store for the muzzled users.
 export const muzzled: Map<string, IMuzzled> = new Map();
 // STore for people who are muzzling others.
@@ -64,7 +63,7 @@ export function addUserToMuzzled(
     // Add requestor to muzzlers
     muzzlers.set(requestor, {
       muzzleCount,
-      muzzleCountRemover: window.setTimeout(
+      muzzleCountRemover: setTimeout(
         () => decrementMuzzleCount(requestor),
         MAX_TIME_BETWEEN_MUZZLES
       )
@@ -74,10 +73,12 @@ export function addUserToMuzzled(
       muzzlers.has(requestor) &&
       muzzlers.get(requestor)!.muzzleCountRemover
     ) {
-      window.clearTimeout(muzzlers.get(requestor)!.muzzleCountRemover);
+      const currentTimer = muzzlers.get(requestor)!
+        .muzzleCountRemover as NodeJS.Timeout;
+      clearTimeout(currentTimer);
       muzzlers.set(requestor, {
         muzzleCount: muzzlers.get(requestor)!.muzzleCount,
-        muzzleCountRemover: window.setTimeout(
+        muzzleCountRemover: setTimeout(
           () =>
             muzzlers.get(requestor)!.muzzleCount === MAX_MUZZLES
               ? removeMuzzler(requestor)
@@ -89,7 +90,7 @@ export function addUserToMuzzled(
     console.log(
       `${friendlyMuzzle} is now muzzled for ${timeToMuzzle} milliseconds`
     );
-    window.setTimeout(() => removeMuzzle(toMuzzle), timeToMuzzle);
+    setTimeout(() => removeMuzzle(toMuzzle), timeToMuzzle);
     return `Succesfully muzzled ${friendlyMuzzle} for ${
       +seconds === 60
         ? minutes + 1 + "m00s"
@@ -117,7 +118,7 @@ export function decrementMuzzleCount(requestor: string) {
 export function removeMuzzler(user: string) {
   muzzlers.delete(user);
   console.log(
-    `${MAX_MUZZLE_TIME} has passed since ${user} last successful muzzle. They have been removed.`
+    `${MAX_MUZZLE_TIME} has passed since ${user} last successful muzzle. They have been removed from muzzlers.`
   );
 }
 


### PR DESCRIPTION
- Adds a cooldown that decrements a requestor's `muzzleCount` every hour to ensure that the `muzzleCount` is tracked hourly.